### PR TITLE
Generalize attributes

### DIFF
--- a/graph_query.cc
+++ b/graph_query.cc
@@ -588,22 +588,7 @@ bool does_span_satisfy_condition(
 
 		std::string current_span_id = hex_str(sp->span_id(), sp->span_id().length());
 		if (current_span_id == span_id) {
-			switch (condition.node_property_name) {
-				case Latency:
-					return does_latency_condition_hold(sp, condition);
-				case Start_time:
-					return does_start_time_condition_hold(sp, condition);
-				case End_time:
-					return does_end_time_condition_hold(sp, condition);
-				case Attribute_parent_name:
-					std::cerr << "Under construction." << std::endl;
-					exit(1);
-				default:
-					std::cerr << "Condition not supported." << std::endl;
-					exit(1);
-			}
-
-			break;
+            return does_condition_hold(sp, condition);
 		}
 	}
 

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -29,7 +29,8 @@ int main(int argc, char* argv[]) {
 
     // querying
     auto client = gcs::Client();
-    std::vector<std::string> total = get_traces_by_structure(query_trace, 1651696797, 1651696798, conditions, &client);
+    //std::vector<std::string> total = get_traces_by_structure(query_trace, 1651700420, 1651876502, conditions, &client);
+    std::vector<std::string> total = get_traces_by_structure(query_trace, 1651700420, 1651700450, conditions, &client);
     std::cout << "Total results: " << total.size() << std::endl;
     return 0;
 }

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -18,18 +18,14 @@ int main(int argc, char* argv[]) {
 
     query_condition condition1;
     condition1.node_index = 2;
-    condition1.node_property_name = Latency;
+    condition1.type = int_value;
+    get_value_func condition_1_union;
+    condition_1_union.int_func = &opentelemetry::proto::trace::v1::Span::start_time_unix_nano;
+    condition1.func = condition_1_union;
     condition1.node_property_value = "10000000";  // 1e+7 ns, 10 ms
     condition1.comp = Lesser_than;
 
-    query_condition condition2;
-    condition2.node_index = 2;
-    condition2.node_property_name = Latency;
-    condition2.node_property_value = "10000000";  // 1e+7 ns, 10 ms
-    condition2.comp = Lesser_than;
-
     conditions.push_back(condition1);
-    conditions.push_back(condition2);
 
     // querying
     auto client = gcs::Client();

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -29,7 +29,6 @@ int main(int argc, char* argv[]) {
 
     // querying
     auto client = gcs::Client();
-    //std::vector<std::string> total = get_traces_by_structure(query_trace, 1651700420, 1651876502, conditions, &client);
     std::vector<std::string> total = get_traces_by_structure(query_trace, 1651700420, 1651700450, conditions, &client);
     std::cout << "Total results: " << total.size() << std::endl;
     return 0;

--- a/query_conditions.cc
+++ b/query_conditions.cc
@@ -5,9 +5,9 @@ bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_
     switch (condition.type) {
         case string_value: {
             std::string span_value = (sp->*condition.func.string_func)();
-            switch(condition.comp) {
+            switch (condition.comp) {
                 case Equal_to:
-                    return span_value.compare(condition.node_property_value)==0;
+                    return span_value.compare(condition.node_property_value) == 0;
                 default:
                     return span_value.compare(condition.node_property_value);
             }
@@ -20,36 +20,33 @@ bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_
             } else {
                 span_val = "true";
             }
-            switch(condition.comp) {
+            switch (condition.comp) {
                 case Equal_to:
-                    return span_val.compare(condition.node_property_value)==0;
+                    return span_val.compare(condition.node_property_value) == 0;
                 default:
-                    return false; // it is undefined to be "less than" or "greater than" a bool
+                    return false;  // it is undefined to be "less than" or "greater than" a bool
             }
         }
         case int_value: {
             int span_val = (sp->*condition.func.int_func)();
             int cond_val = std::stoi(condition.node_property_value);
-            switch(condition.comp) {
+            switch (condition.comp) {
                 case Equal_to: return span_val == cond_val;
                 case Lesser_than: return span_val < cond_val;
                 case Greater_than: return span_val > cond_val;
             }
-
         }
         case double_value: {
             double span_val = (sp->*condition.func.double_func)();
             double cond_val = std::stod(condition.node_property_value);
-            switch(condition.comp) {
+            switch (condition.comp) {
                 case Equal_to: return span_val == cond_val;
                 case Lesser_than: return span_val < cond_val;
                 case Greater_than: return span_val > cond_val;
             }
-
         }
         case bytes_value: {
-            // TODO:  not sure how to do this
-
+            // TODO(jessica)  not sure how to do this
         }
     }
 }

--- a/query_conditions.cc
+++ b/query_conditions.cc
@@ -3,6 +3,62 @@
 
 #include "query_conditions.h"
 
+
+bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition) {
+    std::string new_value = (sp->*condition.func.string_func)();
+
+    switch (condition.type) {
+        case string_value: {
+            std::string span_value = (sp->*condition.func.string_func)();
+            switch(condition.comp) {
+                case Equal_to:
+                    return span_value.compare(condition.node_property_value)==0;
+                default:
+                    return span_value.compare(condition.node_property_value);
+            }
+        }
+        case bool_value: {
+            bool val = (sp->*condition.func.bool_func)();
+            std::string span_val;
+            if (val) {
+                span_val = "false";
+            } else {
+                span_val = "true";
+            }
+            switch(condition.comp) {
+                case Equal_to:
+                    return span_val.compare(condition.node_property_value)==0;
+                default:
+                    return false; // it is undefined to be "less than" or "greater than" a bool
+            }
+        }
+        case int_value: {
+            int span_val = (sp->*condition.func.int_func)();
+            int cond_val = std::stoi(condition.node_property_value);
+            switch(condition.comp) {
+                case Equal_to: return span_val == cond_val;
+                case Lesser_than: return span_val < cond_val;
+                case Greater_than: return span_val > cond_val;
+            }
+
+        }
+        case double_value: {
+            double span_val = (sp->*condition.func.double_func)();
+            double cond_val = std::stod(condition.node_property_value);
+            switch(condition.comp) {
+                case Equal_to: return span_val == cond_val;
+                case Lesser_than: return span_val < cond_val;
+                case Greater_than: return span_val > cond_val;
+            }
+
+        }
+        case bytes_value: {
+            // TODO:  not sure how to do this
+
+        }
+    }
+}
+
 /**
  * TODO: There got to be a concise way to do all this stuff.. directly getting function name
  * from `condition` and invoking that using `reflection` maybe???

--- a/query_conditions.cc
+++ b/query_conditions.cc
@@ -1,12 +1,7 @@
-// Copyright 2022 Haseeb LLC
-// @author: Muhammad Haseeb <mh6218@nyu.edu>
-
 #include "query_conditions.h"
 
 
 bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition) {
-    std::string new_value = (sp->*condition.func.string_func)();
-
     switch (condition.type) {
         case string_value: {
             std::string span_value = (sp->*condition.func.string_func)();
@@ -76,7 +71,6 @@ bool does_latency_condition_hold(const opentelemetry::proto::trace::v1::Span* sp
         case Greater_than:
             return latency > std::stol(condition.node_property_value);
         default:
-            std::cout << "damnn" << std::endl;
             return false;
     }
 

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -20,12 +20,33 @@ enum node_properties {
 	Attribute_parent_name  // string
 };
 
+enum property_type {
+    string_value,
+    bool_value,
+    int_value,
+    double_value,
+    bytes_value
+};
+
+
+//https://stackoverflow.com/questions/16770690/function-pointer-to-different-functions-with-different-arguments-in-c
+typedef union {
+  std::string (opentelemetry::proto::trace::v1::Span::*string_func)() const;
+  bool (opentelemetry::proto::trace::v1::Span::*bool_func)() const;
+  uint64_t (opentelemetry::proto::trace::v1::Span::*int_func)() const;
+  double (opentelemetry::proto::trace::v1::Span::*double_func)() const;
+  char* (opentelemetry::proto::trace::v1::Span::*bytes_func)() const;
+} get_value_func;
+
 struct query_condition {
 	int node_index;
-    node_properties node_property_name;
+    property_type type;
+    get_value_func func;
 	std::string node_property_value;
 	property_comparison comp;
 };
+
+bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 
 bool does_latency_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 bool does_start_time_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -1,6 +1,3 @@
-// Copyright 2022 Haseeb LLC
-// @author: Muhammad Haseeb <mh6218@nyu.edu>
-
 #ifndef QUERY_CONDITIONS_H_
 #define QUERY_CONDITIONS_H_
 

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -1,5 +1,5 @@
-#ifndef QUERY_CONDITIONS_H_
-#define QUERY_CONDITIONS_H_
+#ifndef QUERY_CONDITIONS_H_  // NOLINT
+#define QUERY_CONDITIONS_H_  // NOLINT
 
 #include <string>
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
@@ -26,7 +26,7 @@ enum property_type {
 };
 
 
-//https://stackoverflow.com/questions/16770690/function-pointer-to-different-functions-with-different-arguments-in-c
+// https://stackoverflow.com/questions/16770690/function-pointer-to-different-functions-with-different-arguments-in-c
 typedef union {
   std::string (opentelemetry::proto::trace::v1::Span::*string_func)() const;
   bool (opentelemetry::proto::trace::v1::Span::*bool_func)() const;
@@ -49,4 +49,4 @@ bool does_latency_condition_hold(const opentelemetry::proto::trace::v1::Span* sp
 bool does_start_time_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 bool does_end_time_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 
-#endif  // QUERY_CONDITIONS_H_
+#endif  // QUERY_CONDITIONS_H_ // NOLINT


### PR DESCRIPTION
This generalizes attributes so that we can take any attribute from the OpenTelemetry spec and query for it.  Can do ints, booleans, strings, but not untyped bytes.