### PR TITLE
Clean up bloom tree

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -116,6 +116,7 @@ cc_binary(
     ],
     deps = [
         "//:graph_query_lib",
+        "//:query_bloom_index",
         "@com_github_googleapis_google_cloud_cpp//:storage",
         "@boost//:algorithm",
         "@boost//:graph",
@@ -202,8 +203,28 @@ cc_binary(
         "graph_query_main.cc",
     ],
     deps = [
+        "//:query_bloom_index",
         "//:graph_query_lib",
         "//:get_traces_by_structure",
         "//:common",
     ],
+)
+
+cc_library(
+    name = "query_bloom_index",
+    srcs = [
+        "query_bloom_index.cc",
+        "query_bloom_index.h",
+    ],
+    hdrs = ["query_bloom_index.h"],
+    deps = [
+        "//:id_index_lib",
+        "//:common",
+        "@com_github_googleapis_google_cloud_cpp//:storage",
+        "@boost//:regex",
+        "@boost//:algorithm",
+        "@com_google_protobuf//:protobuf",
+        "@com_github_opentelemetry_proto//:trace_service_proto_cc",
+    ],
+    visibility = ["//main:__pkg__"],
 )

--- a/common.h
+++ b/common.h
@@ -26,9 +26,9 @@ const char BUCKET_TYPE_LABEL_VALUE_FOR_SPAN_BUCKETS[] = "microservice";
 const char PROJECT_ID[] = "dynamic-tracing";
 const char BUCKETS_LOCATION[] = "us-central1";
 
-const char TRACE_STRUCT_BUCKET[] = "dyntraces-snicket3";
-const char TRACE_HASHES_BUCKET[] = "tracehashes-snicket3";
-const char SERVICES_BUCKETS_SUFFIX[] = "-snicket3";
+const char TRACE_STRUCT_BUCKET[] = "dyntraces-snicket4";
+const char TRACE_HASHES_BUCKET[] = "tracehashes-snicket4";
+const char SERVICES_BUCKETS_SUFFIX[] = "-snicket4";
 
 const char TRACE_STRUCT_BUCKET_PREFIX[] = "dyntraces";
 const int TRACE_ID_LENGTH = 32;

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -1,5 +1,6 @@
 #include "get_traces_by_structure.h"
 #include "graph_query.h"
+#include "query_bloom_index.h"
 
 int main(int argc, char* argv[]) {
     // query trace structure
@@ -28,8 +29,12 @@ int main(int argc, char* argv[]) {
 
     // querying
     auto client = gcs::Client();
+    /*
     auto total = get_traces_by_structure(query_trace, 1653317532, 1653317532, &client);
     std::cout << "Total traces: " << total.trace_ids.size() << std::endl;
     std::cout << "ID: " << total.trace_ids[0] << std::endl;
+    */
+    std::string batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "new_id_index");
+    std::cout << "batch " << batch << std::endl;
     return 0;
 }

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -534,51 +534,10 @@ std::vector<struct BatchObjectNames> split_batches_by_leaf(
     return to_return;
 }
 
-bool is_trace_id_in_nonterminal_node(
-    gcs::Client* client, std::string traceID, time_t start_time, time_t end_time
-) {
-    std::string bloom_filter_name = std::to_string(start_time) + "-" + std::to_string(end_time);
-    auto reader = client->ReadObject(index_bucket, bloom_filter_name);
-    if (reader.status().code() == ::google::cloud::StatusCode::kNotFound) {
-        return false;  // if it doesn't exist, then you can't get the trace there
-    }
-    if (!reader) {
-        std::cerr << "Error reading object: " << reader.status() << bloom_filter_name << "\n";
-        throw std::runtime_error("Error reading node object");
-    }
-    bloom_filter bf;
-    bf.Deserialize(reader);
-    const char* traceID_c_str = traceID.c_str();
-    size_t len = traceID.length();
-    return bf.contains(traceID_c_str, len);
-}
-
-std::vector<std::string> is_trace_id_in_leaf(
-    gcs::Client* client, std::string traceID, time_t start_time, time_t end_time) {
-    std::vector<std::string> to_return;
-    const char* traceID_c_str = traceID.c_str();
-    size_t len = traceID.length();
-    std::string leaf_name = std::to_string(start_time) + "-" + std::to_string(end_time);
-    auto reader = client->ReadObject(index_bucket, leaf_name);
-    if (reader.status().code() == ::google::cloud::StatusCode::kNotFound) {
-        return to_return;  // if it doesn't exist, then you can't get the trace there
-    } else if (!reader) {
-        std::cerr << "Error reading object: " << reader.status() << "\n";
-        throw std::runtime_error("Error reading leaf object");
-    }
-    Leaf leaf = deserialize_leaf(reader);
-    for (int i=0; i < leaf.batch_names.size(); i++) {
-        if (leaf.bloom_filters[i].contains(traceID_c_str, len)) {
-            to_return.push_back(leaf.batch_names[i]);
-        }
-    }
-    return to_return;
-}
-
-void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity) {
+void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib) {
     // get root and granularity from labels
     StatusOr<gcs::BucketMetadata> bucket_metadata =
-      client->GetBucketMetadata(index_bucket);
+      client->GetBucketMetadata(ib);
     if (!bucket_metadata) {
         throw std::runtime_error(bucket_metadata.status().message());
     }
@@ -596,93 +555,6 @@ void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &r
     }
 }
 
-std::vector<std::tuple<time_t, time_t>> get_children(std::tuple<time_t, time_t> parent, time_t granularity) {
-    time_t chunk_size = (std::get<1>(parent)-std::get<0>(parent))/granularity;
-    std::vector<std::tuple<time_t, time_t>> to_return;
-    for (time_t i=std::get<0>(parent); i < std::get<1>(parent); i += chunk_size) {
-        to_return.push_back(std::make_tuple(i, i+chunk_size));
-    }
-    return to_return;
-}
-
-std::string query_index_for_traceID(gcs::Client* client, std::string traceID) {
-    std::tuple<time_t, time_t> root;
-    time_t granularity;
-    get_root_and_granularity(client, root, granularity);
-
-    std::vector<std::tuple<time_t, time_t>> unvisited_nodes;
-    unvisited_nodes.push_back(root);
-
-    // this will contain lists of batches that have the trace ID according to their bloom filters
-    // this is a vector and not a single value because bloom filters may give false positives
-    std::vector<std::future<std::vector<std::string>>> batches;
-
-    // the way to parallelize this is to do all unvisited_nodes in parallel
-    while (unvisited_nodes.size() > 0) {
-        std::vector<std::tuple<time_t, time_t>> new_unvisited;
-        std::vector<std::future<bool>> got_positive;
-        std::vector<std::tuple<time_t, time_t>> got_positive_limits;
-        for (int i=0; i < unvisited_nodes.size(); i++) {
-            auto visit = unvisited_nodes[i];
-            // process
-            if (std::get<1>(visit)-std::get<0>(visit) == granularity) {
-                // hit a leaf
-                batches.push_back(std::async(std::launch::async, is_trace_id_in_leaf,
-                    client, traceID, std::get<0>(visit), std::get<1>(visit)));
-            } else {
-                // async call if it is in nonterminal node
-                got_positive_limits.push_back(visit);
-                got_positive.push_back(std::async(std::launch::async, is_trace_id_in_nonterminal_node,
-                    client, traceID, std::get<0>(visit), std::get<1>(visit)));
-            }
-        }
-        // now we need to see how many of the non-terminal nodes showed up positive
-        for (int i=0; i < got_positive.size(); i++) {
-            if (got_positive[i].get()) {
-                auto children = get_children(got_positive_limits[i], granularity);
-                for (int j=0; j < children.size(); j++) {
-                    new_unvisited.push_back(children[j]);
-                }
-            }
-        }
-        unvisited_nodes.clear();
-        for (int i=0; i < new_unvisited.size(); i++) {
-            unvisited_nodes.push_back(new_unvisited[i]);
-        }
-    }
-    // now figure out which of the batches actually have your trace ID
-    // because false positives are a thing, this could potentially be more than one batch that shows up true
-    std::vector<std::string> verified_batches;
-    for (int i=0; i < batches.size(); i++) {
-        std::vector<std::string> verified = batches[i].get();
-        for (int j=0; j < verified.size(); j++) {
-            verified_batches.push_back(verified[j]);
-        }
-    }
-
-    // this is the common case:  no false positives
-    if (verified_batches.size() == 1) {
-        return verified_batches[0];
-    }
-
-    // else we need to actually look up the trace structure objects to differentiate
-    std::string trace_struct_bucket(TRACE_STRUCT_BUCKET_PREFIX);
-    std::string suffix(SERVICES_BUCKETS_SUFFIX);
-    trace_struct_bucket += suffix;
-    for (int i=0; i < verified_batches.size(); i++) {
-        auto reader = client->ReadObject(trace_struct_bucket, verified_batches[i]);
-        if (!reader) {
-            std::cerr << "Error reading object: " << reader.status() << "\n";
-            throw std::runtime_error("Error reading trace object");
-        } else {
-            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
-            if (contents.find(traceID) != -1) {
-                return verified_batches[i];
-            }
-        }
-    }
-    return "";
-}
 
 int update_index(gcs::Client* client, time_t last_updated) {
     time_t now;
@@ -709,7 +581,5 @@ int update_index(gcs::Client* client, time_t last_updated) {
         leaves.push_back(leaves_future[i].get());
     }
     bubble_up_leaves(client, last_updated, to_update, leaves, granularity);
-    std::string batch = query_index_for_traceID(client, "c5367e16e960a3452529e44d035a9bec");
-    std::cout << "batch " << batch << std::endl;
     return 0;
 }

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -292,7 +292,8 @@ bloom_filter create_bloom_filter_partial_batch(gcs::Client* client, std::string 
 }
 
 
-Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time, time_t end_time, std::string index_bucket) {
+Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch,
+    time_t start_time, time_t end_time, std::string index_bucket) {
     Leaf leaf;
     leaf.start_time = start_time;
     leaf.end_time = end_time;
@@ -542,7 +543,8 @@ std::vector<struct BatchObjectNames> split_batches_by_leaf(
     return to_return;
 }
 
-void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib) {
+void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root,
+    time_t &granularity, std::string ib) {
     // get root and granularity from labels
     StatusOr<gcs::BucketMetadata> bucket_metadata =
       client->GetBucketMetadata(ib);
@@ -570,10 +572,10 @@ time_t get_lowest_time_val(gcs::Client* client) {
     time_t now;
     time(&now);
     time_t lowest_val = now;
-    for (int i=0; i<10; i++) {
-        for (int j=0; j<10; j++) {
+    for (int i=0; i < 10; i++) {
+        for (int j=0; j < 10; j++) {
             std::string prefix = std::to_string(i) + std::to_string(j);
-            for (auto&& object_metadata : 
+            for (auto&& object_metadata :
                 client->ListObjects(bucket_name, gcs::Prefix(prefix))) {
                 if (!object_metadata) {
                     throw std::runtime_error(object_metadata.status().message());
@@ -588,7 +590,6 @@ time_t get_lowest_time_val(gcs::Client* client) {
                 break;
             }
         }
-
     }
     return lowest_val;
 }
@@ -600,13 +601,9 @@ int update_index(gcs::Client* client, std::string index_bucket, time_t granulari
     time_t last_updated = create_index_bucket(client, index_bucket);
     if (last_updated == 0) {
         last_updated = get_lowest_time_val(client);
-        std::cout << "last updated mod granularity is " << last_updated%granularity << std::endl;
-        std::cout << "last updated is " << last_updated << std::endl;
         last_updated = last_updated - (last_updated%granularity);
     }
-    std::cout << "last updated " << last_updated << std::endl;
     time_t to_update = last_updated + (20*granularity);
-    std::cout << "to update " << to_update << std::endl;
 
     std::vector<std::string> batches = get_batches_between_timestamps(client, last_updated, to_update);
     std::vector<BatchObjectNames> batches_by_leaf = split_batches_by_leaf(

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -710,5 +710,6 @@ int update_index(gcs::Client* client, time_t last_updated) {
     }
     bubble_up_leaves(client, last_updated, to_update, leaves, granularity);
     std::string batch = query_index_for_traceID(client, "c5367e16e960a3452529e44d035a9bec");
+    std::cout << "batch " << batch << std::endl;
     return 0;
 }

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -20,7 +20,7 @@
 
 // TODO(jessica): these are already defined in common under different names
 const char trace_struct_bucket[] = "dyntraces-snicket4";
-const char index_bucket[] = "idindex-snicket4";
+const char index_bucket[] = "new_id_index";
 const int branching_factor = 10;
 
 // Leaf struct

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -20,7 +20,6 @@
 
 // TODO(jessica): these are already defined in common under different names
 const char trace_struct_bucket[] = "dyntraces-snicket4";
-const char index_bucket[] = "new_id_index";
 const int branching_factor = 10;
 
 // Leaf struct
@@ -51,13 +50,12 @@ std::vector<std::string> generate_prefixes(time_t earliest, time_t latest);
 std::vector<std::string> get_batches_between_timestamps(gcs::Client* client, time_t earliest, time_t latest);
 bloom_filter create_bloom_filter_partial_batch(gcs::Client* client, std::string batch, time_t earliest, time_t latest);
 bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string batch);
-Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time, time_t end_time);
-int bubble_up_leaf(gcs::Client* client, time_t start_time, time_t end_time, Leaf &leaf);
+Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time, time_t end_time, std::string index_bucket);
+int bubble_up_leaf(gcs::Client* client, time_t start_time, time_t end_time, Leaf &leaf, std::string index_bucket);
 std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
-int create_index_bucket(gcs::Client* client);
-std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
-int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf);
-int update_index(gcs::Client* client, time_t last_updated);
+int create_index_bucket(gcs::Client* client, std::string index_bucket);
+int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf, std::string index_bucket);
+int update_index(gcs::Client* client, time_t last_updated, std::string index_bucket);
 void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib);
 
 

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -58,6 +58,7 @@ int create_index_bucket(gcs::Client* client);
 std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
 int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf);
 int update_index(gcs::Client* client, time_t last_updated);
+void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib);
 
 
 

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -50,13 +50,15 @@ std::vector<std::string> generate_prefixes(time_t earliest, time_t latest);
 std::vector<std::string> get_batches_between_timestamps(gcs::Client* client, time_t earliest, time_t latest);
 bloom_filter create_bloom_filter_partial_batch(gcs::Client* client, std::string batch, time_t earliest, time_t latest);
 bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string batch);
-Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time, time_t end_time, std::string index_bucket);
+Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time,
+    time_t end_time, std::string index_bucket);
 int bubble_up_leaf(gcs::Client* client, time_t start_time, time_t end_time, Leaf &leaf, std::string index_bucket);
 std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
 time_t create_index_bucket(gcs::Client* client, std::string index_bucket);
 int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf, std::string index_bucket);
 int update_index(gcs::Client* client, std::string index_bucket, time_t granularity);
-void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib);
+void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root,
+    time_t &granularity, std::string ib);
 
 
 

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -53,9 +53,9 @@ bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string b
 Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time, time_t end_time, std::string index_bucket);
 int bubble_up_leaf(gcs::Client* client, time_t start_time, time_t end_time, Leaf &leaf, std::string index_bucket);
 std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
-int create_index_bucket(gcs::Client* client, std::string index_bucket);
+time_t create_index_bucket(gcs::Client* client, std::string index_bucket);
 int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf, std::string index_bucket);
-int update_index(gcs::Client* client, time_t last_updated, std::string index_bucket);
+int update_index(gcs::Client* client, std::string index_bucket, time_t granularity);
 void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root, time_t &granularity, std::string ib);
 
 

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -4,7 +4,6 @@ int main(int argc, char* argv[]) {
     // Create a client to communicate with Google Cloud Storage. This client
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
-    //time_t last_updated = 1651700400;
     update_index(&client, "new_id_index", 10);
     return 0;
 }

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -5,6 +5,6 @@ int main(int argc, char* argv[]) {
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
     time_t last_updated = 1651700400;
-    update_index(&client, last_updated);
+    update_index(&client, last_updated, "new_id_index");
     return 0;
 }

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -4,7 +4,7 @@ int main(int argc, char* argv[]) {
     // Create a client to communicate with Google Cloud Storage. This client
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
-    time_t last_updated = 1651700400;
-    update_index(&client, last_updated, "new_id_index");
+    //time_t last_updated = 1651700400;
+    update_index(&client, "new_id_index", 10);
     return 0;
 }

--- a/query_bloom_index.cc
+++ b/query_bloom_index.cc
@@ -1,0 +1,130 @@
+#include "query_bloom_index.h"
+
+std::vector<std::tuple<time_t, time_t>> get_children(std::tuple<time_t, time_t> parent, time_t granularity) {
+    time_t chunk_size = (std::get<1>(parent)-std::get<0>(parent))/granularity;
+    std::vector<std::tuple<time_t, time_t>> to_return;
+    for (time_t i=std::get<0>(parent); i < std::get<1>(parent); i += chunk_size) {
+        to_return.push_back(std::make_tuple(i, i+chunk_size));
+    }
+    return to_return;
+}
+
+std::vector<std::string> is_trace_id_in_leaf(
+    gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket) {
+    std::vector<std::string> to_return;
+    const char* traceID_c_str = traceID.c_str();
+    size_t len = traceID.length();
+    std::string leaf_name = std::to_string(start_time) + "-" + std::to_string(end_time);
+    auto reader = client->ReadObject(index_bucket, leaf_name);
+    if (reader.status().code() == ::google::cloud::StatusCode::kNotFound) {
+        return to_return;  // if it doesn't exist, then you can't get the trace there
+    } else if (!reader) {
+        std::cerr << "Error reading object: " << reader.status() << "\n";
+        throw std::runtime_error("Error reading leaf object");
+    }
+    Leaf leaf = deserialize_leaf(reader);
+    for (int i=0; i < leaf.batch_names.size(); i++) {
+        if (leaf.bloom_filters[i].contains(traceID_c_str, len)) {
+            to_return.push_back(leaf.batch_names[i]);
+        }
+    }
+    return to_return;
+}
+
+bool is_trace_id_in_nonterminal_node(
+    gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket
+) {
+    std::string bloom_filter_name = std::to_string(start_time) + "-" + std::to_string(end_time);
+    auto reader = client->ReadObject(index_bucket, bloom_filter_name);
+    if (reader.status().code() == ::google::cloud::StatusCode::kNotFound) {
+        return false;  // if it doesn't exist, then you can't get the trace there
+    }
+    if (!reader) {
+        std::cerr << "Error reading object: " << reader.status() << bloom_filter_name << "\n";
+        throw std::runtime_error("Error reading node object");
+    }
+    bloom_filter bf;
+    bf.Deserialize(reader);
+    const char* traceID_c_str = traceID.c_str();
+    size_t len = traceID.length();
+    return bf.contains(traceID_c_str, len);
+}
+
+std::string query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket) {
+    std::tuple<time_t, time_t> root;
+    time_t granularity;
+    get_root_and_granularity(client, root, granularity, index_bucket);
+
+    std::vector<std::tuple<time_t, time_t>> unvisited_nodes;
+    unvisited_nodes.push_back(root);
+
+    // this will contain lists of batches that have the trace ID according to their bloom filters
+    // this is a vector and not a single value because bloom filters may give false positives
+    std::vector<std::future<std::vector<std::string>>> batches;
+
+    // the way to parallelize this is to do all unvisited_nodes in parallel
+    while (unvisited_nodes.size() > 0) {
+        std::vector<std::tuple<time_t, time_t>> new_unvisited;
+        std::vector<std::future<bool>> got_positive;
+        std::vector<std::tuple<time_t, time_t>> got_positive_limits;
+        for (int i=0; i < unvisited_nodes.size(); i++) {
+            auto visit = unvisited_nodes[i];
+            // process
+            if (std::get<1>(visit)-std::get<0>(visit) == granularity) {
+                // hit a leaf
+                batches.push_back(std::async(std::launch::async, is_trace_id_in_leaf,
+                    client, queried_value, std::get<0>(visit), std::get<1>(visit), index_bucket));
+            } else {
+                // async call if it is in nonterminal node
+                got_positive_limits.push_back(visit);
+                got_positive.push_back(std::async(std::launch::async, is_trace_id_in_nonterminal_node,
+                    client, queried_value, std::get<0>(visit), std::get<1>(visit), index_bucket));
+            }
+        }
+        // now we need to see how many of the non-terminal nodes showed up positive
+        for (int i=0; i < got_positive.size(); i++) {
+            if (got_positive[i].get()) {
+                auto children = get_children(got_positive_limits[i], granularity);
+                for (int j=0; j < children.size(); j++) {
+                    new_unvisited.push_back(children[j]);
+                }
+            }
+        }
+        unvisited_nodes.clear();
+        for (int i=0; i < new_unvisited.size(); i++) {
+            unvisited_nodes.push_back(new_unvisited[i]);
+        }
+    }
+    // now figure out which of the batches actually have your trace ID
+    // because false positives are a thing, this could potentially be more than one batch that shows up true
+    std::vector<std::string> verified_batches;
+    for (int i=0; i < batches.size(); i++) {
+        std::vector<std::string> verified = batches[i].get();
+        for (int j=0; j < verified.size(); j++) {
+            verified_batches.push_back(verified[j]);
+        }
+    }
+
+    // this is the common case:  no false positives
+    if (verified_batches.size() == 1) {
+        return verified_batches[0];
+    }
+
+    // else we need to actually look up the trace structure objects to differentiate
+    std::string trace_struct_bucket(TRACE_STRUCT_BUCKET_PREFIX);
+    std::string suffix(SERVICES_BUCKETS_SUFFIX);
+    trace_struct_bucket += suffix;
+    for (int i=0; i < verified_batches.size(); i++) {
+        auto reader = client->ReadObject(trace_struct_bucket, verified_batches[i]);
+        if (!reader) {
+            std::cerr << "Error reading object: " << reader.status() << "\n";
+            throw std::runtime_error("Error reading trace object");
+        } else {
+            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
+            if (contents.find(queried_value) != -1) {
+                return verified_batches[i];
+            }
+        }
+    }
+    return "";
+}

--- a/query_bloom_index.h
+++ b/query_bloom_index.h
@@ -1,0 +1,20 @@
+#ifndef  QUERY_BLOOM_INDEX_H_ // NOLINT
+#define QUERY_BLOOM_INDEX_H_ // NOLINT
+
+#include <stdlib.h>
+#include <time.h>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "id_index/id_index.h"
+
+std::string query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket);
+std::vector<std::string> is_trace_id_in_leaf(
+    gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket);
+bool is_trace_id_in_nonterminal_node(                                           
+    gcs::Client* client, std::string traceID, time_t start_time,
+    time_t end_time, std::string index_bucket
+);
+std::vector<std::tuple<time_t, time_t>> get_children(std::tuple<time_t, time_t> parent, time_t granularity);
+
+#endif // QUERY_BLOOM_INDEX_H // NOLINT

--- a/query_bloom_index.h
+++ b/query_bloom_index.h
@@ -11,7 +11,7 @@
 std::string query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket);
 std::vector<std::string> is_trace_id_in_leaf(
     gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket);
-bool is_trace_id_in_nonterminal_node(                                           
+bool is_trace_id_in_nonterminal_node(
     gcs::Client* client, std::string traceID, time_t start_time,
     time_t end_time, std::string index_bucket
 );


### PR DESCRIPTION
Puts querying in its own location, and cleans up small issues like manually finding the last updated time.