### PR TITLE
Generalize bloom index

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
     ],
     visibility = ["//main:__pkg__"],
 )
+
 cc_library(
     name = "graph_query_lib",
     srcs = [
@@ -134,6 +135,7 @@ cc_binary(
     ],
     deps = [
         "//:id_index_lib",
+        "//:graph_query_lib",
         "@com_github_googleapis_google_cloud_cpp//:storage",
         "@boost//:regex",
         "@boost//:algorithm",

--- a/common.cc
+++ b/common.cc
@@ -228,16 +228,16 @@ std::string extract_trace_from_traces_object(std::string trace_id, std::string& 
 }
 
 void replace_all(std::string& str, const std::string& from, const std::string& to) {
-    if(from.empty()) {                                                          
-        return;                                                                 
-    }                                                                           
-                                                                                
-    size_t start_pos = 0;                                                       
-    while((start_pos = str.find(from, start_pos)) != std::string::npos) {       
-        str.replace(start_pos, from.length(), to);                              
+    if (from.empty()) {
+        return;
+    }
+
+    size_t start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
         start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
-    }                                                                           
-} 
+    }
+}
 
 std::vector<std::string> get_spans_buckets_names(gcs::Client* client) {
     std::vector<std::string> response;

--- a/common.cc
+++ b/common.cc
@@ -227,4 +227,37 @@ std::string extract_trace_from_traces_object(std::string trace_id, std::string& 
 	return trace;
 }
 
+void replace_all(std::string& str, const std::string& from, const std::string& to) {
+    if(from.empty()) {                                                          
+        return;                                                                 
+    }                                                                           
+                                                                                
+    size_t start_pos = 0;                                                       
+    while((start_pos = str.find(from, start_pos)) != std::string::npos) {       
+        str.replace(start_pos, from.length(), to);                              
+        start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }                                                                           
+} 
 
+std::vector<std::string> get_spans_buckets_names(gcs::Client* client) {
+    std::vector<std::string> response;
+
+    for (auto&& bucket_metadata : client->ListBucketsForProject(PROJECT_ID)) {
+        if (!bucket_metadata) {
+            std::cerr << bucket_metadata.status().message() << std::endl;
+            exit(1);
+        }
+
+        if (true == bucket_metadata->labels().empty()) {
+            continue;
+        }
+
+        for (auto const& kv : bucket_metadata->labels()) {
+            if (kv.first == BUCKET_TYPE_LABEL_KEY && kv.second == BUCKET_TYPE_LABEL_VALUE_FOR_SPAN_BUCKETS) {
+                response.push_back(bucket_metadata->name());
+            }
+        }
+    }
+
+    return response;
+}

--- a/common.h
+++ b/common.h
@@ -47,6 +47,7 @@ typedef std::map<std::string, std::vector<std::string>> objname_to_matching_trac
 std::vector<std::string> split_by_string(std::string& str,  const char* ch);
 std::string hex_str(std::string data, int len);
 std::string strip_from_the_end(std::string object, char stripper);
+void replace_all(std::string& str, const std::string& from, const std::string& to);
 
 /// *********** string processing according to system conventions **********
 std::map<std::string, std::pair<int, int>> get_timestamp_map_for_trace_ids(
@@ -72,5 +73,7 @@ std::vector<std::string> filter_trace_ids_based_on_query_timestamp(
     int start_time,
     int end_time,
     gcs::Client* client);
+
+std::vector<std::string> get_spans_buckets_names(gcs::Client* client);
 
 #endif  // COMMON_H_ // NOLINT

--- a/folders_index/folders_index.cc
+++ b/folders_index/folders_index.cc
@@ -84,29 +84,6 @@ std::vector<std::string> get_all_attr_values(index_batch& current_index_batch) {
 	return response;
 }
 
-std::vector<std::string> get_spans_buckets_names(gcs::Client* client) {
-	std::vector<std::string> response;
-
-	for (auto&& bucket_metadata : client->ListBucketsForProject(PROJECT_ID)) {
-		if (!bucket_metadata) {
-			std::cerr << bucket_metadata.status().message() << std::endl;
-			exit(1);
-		}
-
-		if (true == bucket_metadata->labels().empty()) {
-			continue;
-		}
-
-		for (auto const& kv : bucket_metadata->labels()) {
-			if (kv.first == BUCKET_TYPE_LABEL_KEY && kv.second == BUCKET_TYPE_LABEL_VALUE_FOR_SPAN_BUCKETS) {
-				response.push_back(bucket_metadata->name());
-			}
-		}
-	}
-
-	return response;
-}
-
 std::vector<std::string> get_all_object_names(std::string bucket_name, gcs::Client* client) {
 	std::vector<std::string> response;
 

--- a/folders_index/folders_index.h
+++ b/folders_index/folders_index.h
@@ -70,7 +70,6 @@ std::string serialize_trace_ids(std::vector<std::string>& trace_ids);
 std::unordered_map<std::string, std::vector<std::string>> calculate_attr_to_trace_ids_map_for_microservice(
 	std::string span_bucket_name, std::string object_name, std::string indexed_attribute, gcs::Client* client
 );
-std::vector<std::string> get_spans_buckets_names(gcs::Client* client);
 batch_timestamp extract_batch_timestamps_struct(std::string batch_name);
 std::vector<std::string> get_all_object_names(std::string bucket_name, gcs::Client* client);
 std::vector<std::string> sort_object_names_on_start_time(std::vector<std::string> object_names);

--- a/folders_index/trace_attributes.cc
+++ b/folders_index/trace_attributes.cc
@@ -9,7 +9,7 @@
  */
 std::string get_bucket_name_for_attr(std::string indexed_attribute) {
 	std::string bucket_name = indexed_attribute;
-	replaceAll(bucket_name, ".", "-");
+	replace_all(bucket_name, ".", "-");
 	return "index-" + bucket_name;
 }
 
@@ -21,14 +21,3 @@ std::string get_folder_name_from_attr_value(std::string attr_value) {
 	return attr_value;
 }
 
-void replaceAll(std::string& str, const std::string& from, const std::string& to) {
-	if(from.empty()) {
-		return;
-	}
-
-	size_t start_pos = 0;
-	while((start_pos = str.find(from, start_pos)) != std::string::npos) {
-		str.replace(start_pos, from.length(), to);
-		start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
-	}
-}

--- a/folders_index/trace_attributes.h
+++ b/folders_index/trace_attributes.h
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <string>
+#include "common.h"
 
 const char ATTR_SPAN_KIND[] = "span.kind";
 const char ATTR_NET_PEER_IP[] = "net.peer.ip";
@@ -13,6 +14,5 @@ const char ATTR_HTTP_STATUS_CODE[] = "http.status_code";
 
 std::string get_bucket_name_for_attr(std::string indexed_attribute);
 std::string get_folder_name_from_attr_value(std::string attr_value);
-void replaceAll(std::string& str, const std::string& from, const std::string& to);
 
 #endif  // TRACE_ATTRIBUTES_H_  // NOLINT

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -34,9 +34,13 @@ int main(int argc, char* argv[]) {
     std::cout << "Total traces: " << total.trace_ids.size() << std::endl;
     std::cout << "ID: " << total.trace_ids[0] << std::endl;
     */
-    std::string batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
-    std::cout << "batch " << batch << std::endl;
-    std::string batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "parent-span-id");
-    std::cout << "batch2 " << batch2 << std::endl;
+    objname_to_matching_trace_ids batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
+    for (auto const &pair: batch) {
+        std::cout << "{" << pair.first << std::endl;
+    }
+    objname_to_matching_trace_ids batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "parent-span-id");
+    for (auto const &pair: batch2) {
+        std::cout << "{" << pair.first << std::endl;
+    }
     return 0;
 }

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
     */
     std::string batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
     std::cout << "batch " << batch << std::endl;
-    std::string batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "span-id");
+    std::string batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "parent-span-id");
     std::cout << "batch2 " << batch2 << std::endl;
     return 0;
 }

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -34,13 +34,20 @@ int main(int argc, char* argv[]) {
     std::cout << "Total traces: " << total.trace_ids.size() << std::endl;
     std::cout << "ID: " << total.trace_ids[0] << std::endl;
     */
-    objname_to_matching_trace_ids batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
-    for (auto const &pair: batch) {
+    objname_to_matching_trace_ids batch = query_bloom_index_for_value(
+        &client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
+    for (auto const &pair : batch) {
         std::cout << "{" << pair.first << std::endl;
+        for (int i=0; i < pair.second.size(); i++) {
+            std::cout << "val: " << pair.second[i] << std::endl;
+        }
     }
     objname_to_matching_trace_ids batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "parent-span-id");
-    for (auto const &pair: batch2) {
+    for (auto const &pair : batch2) {
         std::cout << "{" << pair.first << std::endl;
+        for (int i=0; i < pair.second.size(); i++) {
+            std::cout << "val: " << pair.second[i] << std::endl;
+        }
     }
     return 0;
 }

--- a/graph_query_main.cc
+++ b/graph_query_main.cc
@@ -34,7 +34,9 @@ int main(int argc, char* argv[]) {
     std::cout << "Total traces: " << total.trace_ids.size() << std::endl;
     std::cout << "ID: " << total.trace_ids[0] << std::endl;
     */
-    std::string batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "new_id_index");
+    std::string batch = query_bloom_index_for_value(&client, "c5367e16e960a3452529e44d035a9bec", "trace-id");
     std::cout << "batch " << batch << std::endl;
+    std::string batch2 = query_bloom_index_for_value(&client, "52bf6864f72e9adf", "span-id");
+    std::cout << "batch2 " << batch2 << std::endl;
     return 0;
 }

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -286,6 +286,7 @@ std::vector<std::string> get_values_in_span_object(gcs::Client* client, std::str
             tracing_data.resource_spans(0).scope_spans(0).spans(i); 
         to_return.push_back(get_value_as_string(&sp, val_func, prop_type));
     }
+    std::cout << "got " << to_return.size() << " values" << std::endl;
     return to_return;
 }
 
@@ -314,6 +315,7 @@ std::vector<std::string> values_from_trace_id_object(gcs::Client* client, std::s
 
 bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string batch,
     std::string property_name, property_type prop_type, get_value_func val_func) {
+    std::cout << "creating bloom filter entire batch" << std::endl;
     bloom_parameters parameters;
 
     // How many elements roughly do we expect to insert?
@@ -338,6 +340,7 @@ bloom_filter create_bloom_filter_partial_batch(
     gcs::Client* client, std::string batch, time_t earliest, time_t latest,
     std::string property_name, property_type prop_type, get_value_func val_func
 ) {
+    std::cout << "creating bloom filter partial batch" << std::endl;
     bloom_parameters parameters;
 
     // How many elements roughly do we expect to insert?

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -259,8 +259,8 @@ std::vector<std::string> span_ids_from_trace_id_object(gcs::Client* client, std:
             std::vector<std::string> sp = split_by_string(trace_and_spans[j], colon);
             to_return.push_back(sp[1]);
         }
-
     }
+    return to_return;
 }
 
 std::vector<std::string> get_values_in_span_object(gcs::Client* client, std::string bucket_name,

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -254,7 +254,7 @@ std::vector<std::string> span_ids_from_trace_id_object(gcs::Client* client, std:
     std::vector<std::string> to_return;
     auto batch_split = split_by_string(obj_name, hyphen);
     std::string trace_struct_bucket(TRACE_STRUCT_BUCKET_PREFIX);
-    std::string suffix(SERVICES_BUCKETS_SUFFIX);
+    std::string suffix(BUCKETS_SUFFIX);
     auto reader = client->ReadObject(trace_struct_bucket+suffix, obj_name);
     if (!reader) {
         std::cerr << "Error reading object: " << reader.status() << "\n";

--- a/id_index/id_index.cc
+++ b/id_index/id_index.cc
@@ -278,12 +278,12 @@ std::vector<std::string> get_values_in_span_object(gcs::Client* client, std::str
     opentelemetry::proto::trace::v1::TracesData tracing_data;
     bool ret = tracing_data.ParseFromString(contents);
     if (!ret) {
-        throw std::runtime_error("could not parse span data");              
+        throw std::runtime_error("could not parse span data");
     }
     int sp_size = tracing_data.resource_spans(0).scope_spans(0).spans_size();
-    for (int i=0; i<sp_size; i++) {
-        opentelemetry::proto::trace::v1::Span sp =                          
-            tracing_data.resource_spans(0).scope_spans(0).spans(i); 
+    for (int i=0; i < sp_size; i++) {
+        opentelemetry::proto::trace::v1::Span sp =
+            tracing_data.resource_spans(0).scope_spans(0).spans(i);
         to_return.push_back(get_value_as_string(&sp, val_func, prop_type));
     }
     std::cout << "got " << to_return.size() << " values" << std::endl;

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -17,9 +17,12 @@
 #include "bloom_filter.hpp"
 #include <boost/algorithm/string/regex.hpp>
 #include "graph_query.h"
+#include "query_conditions.h"
 
 // TODO(jessica): these are already defined in common under different names
 const char trace_struct_bucket[] = "dyntraces-snicket4";
+const char SPAN_ID[] = "span.id";
+const char TRACE_ID[] = "trace.id";
 const int branching_factor = 10;
 
 // Leaf struct
@@ -48,15 +51,19 @@ std::vector<struct BatchObjectNames> split_batches_by_leaf(
 // Core code
 std::vector<std::string> generate_prefixes(time_t earliest, time_t latest);
 std::vector<std::string> get_batches_between_timestamps(gcs::Client* client, time_t earliest, time_t latest);
-bloom_filter create_bloom_filter_partial_batch(gcs::Client* client, std::string batch, time_t earliest, time_t latest);
-bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string batch);
+bloom_filter create_bloom_filter_partial_batch(gcs::Client* client, std::string batch, time_t earliest, time_t latest,
+    std::string property_name, property_type prop_type, get_value_func val_func);
+bloom_filter create_bloom_filter_entire_batch(gcs::Client* client, std::string batch,
+    std::string property_name, property_type prop_type, get_value_func val_func);
 Leaf make_leaf(gcs::Client* client, BatchObjectNames &batch, time_t start_time,
-    time_t end_time, std::string index_bucket);
+    time_t end_time, std::string index_bucket,
+    std::string property_name, property_type prop_type, get_value_func val_func);
 int bubble_up_leaf(gcs::Client* client, time_t start_time, time_t end_time, Leaf &leaf, std::string index_bucket);
 std::tuple<time_t, time_t> get_parent(time_t start_time, time_t end_time, time_t granularity);
 time_t create_index_bucket(gcs::Client* client, std::string index_bucket);
 int bubble_up_bloom_filter(gcs::Client* client, bloom_filter bf, std::string index_bucket);
-int update_index(gcs::Client* client, std::string index_bucket, time_t granularity);
+int update_index(gcs::Client* client, std::string property_name, time_t granularity,
+    property_type prop_type, get_value_func val_func);
 void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root,
     time_t &granularity, std::string ib);
 

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -22,7 +22,9 @@
 // TODO(jessica): these are already defined in common under different names
 const char trace_struct_bucket[] = "dyntraces-snicket4";
 const char SPAN_ID[] = "span.id";
+const char SPAN_ID_BUCKET[] = "span-id";
 const char TRACE_ID[] = "trace.id";
+const char TRACE_ID_BUCKET[] = "trace-id";
 const int branching_factor = 10;
 
 // Leaf struct

--- a/id_index/id_index.h
+++ b/id_index/id_index.h
@@ -67,6 +67,4 @@ int update_index(gcs::Client* client, std::string property_name, time_t granular
 void get_root_and_granularity(gcs::Client* client, std::tuple<time_t, time_t> &root,
     time_t &granularity, std::string ib);
 
-
-
 #endif  // MICROSERVICES_ENV_TRACE_STORAGE_ID_INDEX_ID_INDEX_H_ // NOLINT

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -4,6 +4,11 @@ int main(int argc, char* argv[]) {
     // Create a client to communicate with Google Cloud Storage. This client
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
-    update_index(&client, "new_id_index", 10);
+    get_value_func func;
+    func.bytes_func = &opentelemetry::proto::trace::v1::Span::trace_id;
+
+    get_value_func condition_1_union;
+    condition_1_union.int_func = &opentelemetry::proto::trace::v1::Span::start_time_unix_nano;
+    update_index(&client, "trace.id", 10, bytes_value, func);
     return 0;
 }

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -5,8 +5,8 @@ int main(int argc, char* argv[]) {
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
     get_value_func func;
-    func.bytes_func = &opentelemetry::proto::trace::v1::Span::span_id;
+    func.bytes_func = &opentelemetry::proto::trace::v1::Span::parent_span_id;
 
-    update_index(&client, "span.id", 10, bytes_value, func);
+    update_index(&client, "parent.span.id", 10, bytes_value, func);
     return 0;
 }

--- a/id_index/main.cc
+++ b/id_index/main.cc
@@ -5,10 +5,8 @@ int main(int argc, char* argv[]) {
     // uses the default configuration for authentication and project id.
     auto client = gcs::Client();
     get_value_func func;
-    func.bytes_func = &opentelemetry::proto::trace::v1::Span::trace_id;
+    func.bytes_func = &opentelemetry::proto::trace::v1::Span::span_id;
 
-    get_value_func condition_1_union;
-    condition_1_union.int_func = &opentelemetry::proto::trace::v1::Span::start_time_unix_nano;
-    update_index(&client, "trace.id", 10, bytes_value, func);
+    update_index(&client, "span.id", 10, bytes_value, func);
     return 0;
 }

--- a/query_bloom_index.cc
+++ b/query_bloom_index.cc
@@ -50,7 +50,65 @@ bool is_trace_id_in_nonterminal_node(
     return bf.contains(traceID_c_str, len);
 }
 
-std::string query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket) {
+objname_to_matching_trace_ids get_return_value_from_objnames(gcs::Client* client,
+    std::vector<std::string> object_names,
+    std::string index_bucket, std::string queried_value) {
+
+    objname_to_matching_trace_ids to_return;
+    if (index_bucket.compare(TRACE_ID_BUCKET) == 0) {
+        for (int i=0; i < object_names.size(); i++) {
+            auto reader = client->ReadObject(TRACE_STRUCT_BUCKET, object_names[i]);
+            if (!reader) {
+                std::cerr << "Error reading object: " << reader.status() << object_names[i] << "\n";
+                throw std::runtime_error("Error reading node object");
+            }
+            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
+            if (contents.find(queried_value) != -1) {
+                to_return[object_names[i]].push_back(queried_value);
+            }
+        }
+    } else if (index_bucket.compare(SPAN_ID_BUCKET) == 0) {
+        for (int i=0; i < object_names.size(); i++) {
+            auto reader = client->ReadObject(TRACE_STRUCT_BUCKET, object_names[i]);
+            if (!reader) {
+                std::cerr << "Error reading object: " << reader.status() << object_names[i] << "\n";
+                throw std::runtime_error("Error reading node object");
+            }
+            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
+            int index = contents.find(queried_value);
+            if (index != -1) {
+                int trace_id_index = contents.rfind("Trace ID", index);
+                std::string trace_id = contents.substr(trace_id_index + 10, TRACE_ID_LENGTH);
+                to_return[object_names[i]].push_back(trace_id);
+            }
+        }
+    } else {
+        for (int i=0; i < object_names.size(); i++) {
+            auto reader = client->ReadObject(TRACE_STRUCT_BUCKET, object_names[i]);
+            if (!reader) {
+                std::cerr << "Error reading object: " << reader.status() << object_names[i] << "\n";
+                throw std::runtime_error("Error reading node object");
+            }
+            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
+            std::vector<std::string> lines = split_by_string(contents, newline);
+            for (int j=0; j < lines.size(); j++) {
+                int trace_id_index = lines[j].find("Trace ID");
+                if (trace_id_index != -1) {
+                    std::string trace_id = contents.substr(trace_id_index+10, TRACE_ID_LENGTH);
+                    to_return[object_names[i]].push_back(trace_id);
+                }
+
+            }
+        }
+    }
+    return to_return;
+
+}
+// Right now, I return the object name -> all trace IDs in that object, because 
+// the Bloom filter index does not distinguish on a trace-by-trace level
+// trace ID queries and span ID are the exception;  those may be inferred with a single GET.
+// so it's actually more efficient for the index to return what may be a superset
+objname_to_matching_trace_ids query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket) {
     std::tuple<time_t, time_t> root;
     time_t granularity;
     get_root_and_granularity(client, root, granularity, index_bucket);
@@ -105,26 +163,5 @@ std::string query_bloom_index_for_value(gcs::Client* client, std::string queried
         }
     }
 
-    // this is the common case:  no false positives
-    if (verified_batches.size() == 1) {
-        return verified_batches[0];
-    }
-
-    // else we need to actually look up the trace structure objects to differentiate
-    std::string trace_struct_bucket(TRACE_STRUCT_BUCKET_PREFIX);
-    std::string suffix(SERVICES_BUCKETS_SUFFIX);
-    trace_struct_bucket += suffix;
-    for (int i=0; i < verified_batches.size(); i++) {
-        auto reader = client->ReadObject(trace_struct_bucket, verified_batches[i]);
-        if (!reader) {
-            std::cerr << "Error reading object: " << reader.status() << "\n";
-            throw std::runtime_error("Error reading trace object");
-        } else {
-            std::string contents{std::istreambuf_iterator<char>{reader}, {}};
-            if (contents.find(queried_value) != -1) {
-                return verified_batches[i];
-            }
-        }
-    }
-    return "";
+    return get_return_value_from_objnames(client, verified_batches, index_bucket, queried_value); 
 }

--- a/query_bloom_index.cc
+++ b/query_bloom_index.cc
@@ -95,20 +95,25 @@ objname_to_matching_trace_ids get_return_value_from_objnames(gcs::Client* client
                 int trace_id_index = lines[j].find("Trace ID");
                 if (trace_id_index != -1) {
                     std::string trace_id = contents.substr(trace_id_index+10, TRACE_ID_LENGTH);
-                    to_return[object_names[i]].push_back(trace_id);
+                    if (std::find(to_return[object_names[i]].begin(),
+                                  to_return[object_names[i]].end(),
+                                  trace_id)
+                        == to_return[object_names[i]].end()) {
+                        to_return[object_names[i]].push_back(trace_id);
+                    }
                 }
-
             }
         }
     }
     return to_return;
-
 }
-// Right now, I return the object name -> all trace IDs in that object, because 
+
+// Right now, I return the object name -> all trace IDs in that object, because
 // the Bloom filter index does not distinguish on a trace-by-trace level
 // trace ID queries and span ID are the exception;  those may be inferred with a single GET.
 // so it's actually more efficient for the index to return what may be a superset
-objname_to_matching_trace_ids query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket) {
+objname_to_matching_trace_ids query_bloom_index_for_value(
+    gcs::Client* client, std::string queried_value, std::string index_bucket) {
     std::tuple<time_t, time_t> root;
     time_t granularity;
     get_root_and_granularity(client, root, granularity, index_bucket);
@@ -163,5 +168,5 @@ objname_to_matching_trace_ids query_bloom_index_for_value(gcs::Client* client, s
         }
     }
 
-    return get_return_value_from_objnames(client, verified_batches, index_bucket, queried_value); 
+    return get_return_value_from_objnames(client, verified_batches, index_bucket, queried_value);
 }

--- a/query_bloom_index.h
+++ b/query_bloom_index.h
@@ -8,7 +8,7 @@
 #include <tuple>
 #include "id_index/id_index.h"
 
-std::string query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket);
+objname_to_matching_trace_ids query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket);
 std::vector<std::string> is_trace_id_in_leaf(
     gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket);
 bool is_trace_id_in_nonterminal_node(

--- a/query_bloom_index.h
+++ b/query_bloom_index.h
@@ -8,7 +8,8 @@
 #include <tuple>
 #include "id_index/id_index.h"
 
-objname_to_matching_trace_ids query_bloom_index_for_value(gcs::Client* client, std::string queried_value, std::string index_bucket);
+objname_to_matching_trace_ids query_bloom_index_for_value(
+    gcs::Client* client, std::string queried_value, std::string index_bucket);
 std::vector<std::string> is_trace_id_in_leaf(
     gcs::Client* client, std::string traceID, time_t start_time, time_t end_time, std::string index_bucket);
 bool is_trace_id_in_nonterminal_node(

--- a/query_conditions.cc
+++ b/query_conditions.cc
@@ -1,7 +1,8 @@
 #include "query_conditions.h"
 
-std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp, get_value_func val_func, property_type prop_type) {
-    switch(prop_type) {
+std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp,
+    get_value_func val_func, property_type prop_type) {
+    switch (prop_type) {
         case string_value:
             return (sp->*val_func.string_func)();
         case bool_value: {

--- a/query_conditions.cc
+++ b/query_conditions.cc
@@ -1,5 +1,36 @@
 #include "query_conditions.h"
 
+std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp, get_value_func val_func, property_type prop_type) {
+    switch(prop_type) {
+        case string_value:
+            return (sp->*val_func.string_func)();
+        case bool_value: {
+            bool val = (sp->*val_func.bool_func)();
+            std::string span_val;
+            if (val) {
+                span_val = "false";
+            } else {
+                span_val = "true";
+            }
+            return span_val;
+        }
+        case int_value: {
+            int val = ((sp->*val_func.int_func)());
+            return std::to_string(val);
+        }
+        case double_value: {
+            double val = ((sp->*val_func.double_func)());
+            return std::to_string(val);
+        }
+        case bytes_value: {
+            std::string bytes_str = ((sp->*val_func.bytes_func)());
+            return hex_str(bytes_str, bytes_str.size());
+        }
+        default:
+            return "";
+    }
+}
+
 
 bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition) {
     switch (condition.type) {

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -16,7 +16,7 @@ typedef union {
   bool (opentelemetry::proto::trace::v1::Span::*bool_func)() const;
   uint64_t (opentelemetry::proto::trace::v1::Span::*int_func)() const;
   double (opentelemetry::proto::trace::v1::Span::*double_func)() const;
-  char* (opentelemetry::proto::trace::v1::Span::*bytes_func)() const;
+  const std::string &(opentelemetry::proto::trace::v1::Span::*bytes_func)() const;
 } get_value_func;
 
 enum property_type {

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
+#include "common.h"
 
 enum property_comparison {
 	Equal_to,
@@ -41,6 +42,7 @@ struct query_condition {
 	property_comparison comp;
 };
 
+std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp, get_value_func val_func, property_type prop_type);
 bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 
 bool does_latency_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);

--- a/query_conditions.h
+++ b/query_conditions.h
@@ -17,7 +17,7 @@ typedef union {
   bool (opentelemetry::proto::trace::v1::Span::*bool_func)() const;
   uint64_t (opentelemetry::proto::trace::v1::Span::*int_func)() const;
   double (opentelemetry::proto::trace::v1::Span::*double_func)() const;
-  const std::string &(opentelemetry::proto::trace::v1::Span::*bytes_func)() const;
+  const std::string &(opentelemetry::proto::trace::v1::Span::*bytes_func)() const; // NOLINT
 } get_value_func;
 
 enum property_type {
@@ -42,7 +42,8 @@ struct query_condition {
 	property_comparison comp;
 };
 
-std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp, get_value_func val_func, property_type prop_type);
+std::string get_value_as_string(const opentelemetry::proto::trace::v1::Span* sp,
+    get_value_func val_func, property_type prop_type);
 bool does_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);
 
 bool does_latency_condition_hold(const opentelemetry::proto::trace::v1::Span* sp, query_condition condition);


### PR DESCRIPTION
Generalizes bloom index to any possible value.  Also makes sure it creates buckets with labels, and returns an object name -> trace ID mapping.

Note that the mapping it returns might be a superset if the indexed value is not trace or span ID.