### PR TITLE
Hex str improvements

### DIFF
--- a/common.cc
+++ b/common.cc
@@ -53,6 +53,24 @@ std::string hex_str(const std::string &data, int len) {
     return s;
 }
 
+bool is_same_hex_str(const std::string &data, int len, std::string &compare) {
+    assert(compare.size() == len*2);
+    constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    for (int i = 0; i < len; ++i) {
+    
+        if (compare[2 * i] != hexmap[(data[i] & 0xF0) >> 4]) {
+            return false;
+        }
+        
+        if (compare[2 * i + 1]  != hexmap[data[i] & 0x0F]) {
+            return false;
+        }
+    }
+    return true;
+
+}
+
 
 
 opentelemetry::proto::trace::v1::TracesData read_object_and_parse_traces_data(
@@ -175,6 +193,7 @@ std::vector<std::string> filter_trace_ids_based_on_query_timestamp(
 
     return response;
 }
+
 std::map<std::string, std::string> get_trace_id_to_root_service_map(std::string object_content) {
     std::map<std::string, std::string> response;
     std::vector<std::string> all_traces = split_by_string(object_content, "Trace ID: ");

--- a/common.cc
+++ b/common.cc
@@ -58,17 +58,15 @@ bool is_same_hex_str(const std::string &data, int len, std::string &compare) {
     constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
     for (int i = 0; i < len; ++i) {
-    
         if (compare[2 * i] != hexmap[(data[i] & 0xF0) >> 4]) {
             return false;
         }
-        
+
         if (compare[2 * i + 1]  != hexmap[data[i] & 0x0F]) {
             return false;
         }
     }
     return true;
-
 }
 
 

--- a/common.h
+++ b/common.h
@@ -53,6 +53,7 @@ enum index_type {
 /// **************** pure string processing ********************************
 std::vector<std::string> split_by_string(std::string& str,  const char* ch);
 std::string hex_str(const std::string &data, int len);
+bool is_same_hex_str(const std::string &data, int len, std::string &compare);
 std::string strip_from_the_end(std::string object, char stripper);
 void replace_all(std::string& str, const std::string& from, const std::string& to);
 void print_progress(float progress, std::string label, bool verbose);

--- a/get_traces_by_structure.cc
+++ b/get_traces_by_structure.cc
@@ -158,7 +158,7 @@ traces_by_structure process_trace_hashes_prefix_and_retrieve_relevant_trace_ids(
     return to_return;
 }
 
-std::string get_root_service_name(std::string trace) {
+std::string get_root_service_name(std::string &trace) {
     std::vector<std::string> trace_lines = split_by_string(trace, newline);
     for (auto line : trace_lines) {
         if (line.substr(0, 1) == ":") {
@@ -171,11 +171,11 @@ std::string get_root_service_name(std::string trace) {
 }
 
 std::vector<std::string> filter_trace_ids_based_on_query_timestamp(
-    std::vector<std::string> trace_ids,
-    std::string batch_name,
+    std::vector<std::string> &trace_ids,
+    std::string &batch_name,
     int start_time,
     int end_time,
-    std::string root_service_name,
+    std::string &root_service_name,
     gcs::Client* client) {
     std::vector<std::string> response;
 
@@ -206,7 +206,7 @@ std::vector<std::string> filter_trace_ids_based_on_query_timestamp(
  * @return std::vector<std::unordered_map<int, int>>
  */
 std::vector<std::unordered_map<int, int>> get_isomorphism_mappings(
-    trace_structure candidate_trace, trace_structure query_trace) {
+    trace_structure &candidate_trace, trace_structure &query_trace) {
     graph_type candidate_graph = morph_trace_structure_to_boost_graph_type(candidate_trace);
     graph_type query_graph = morph_trace_structure_to_boost_graph_type(query_trace);
 
@@ -229,7 +229,7 @@ std::vector<std::unordered_map<int, int>> get_isomorphism_mappings(
     return isomorphism_maps;
 }
 
-std::vector<std::string> get_trace_ids_from_trace_hashes_object(std::string object_name, gcs::Client* client) {
+std::vector<std::string> get_trace_ids_from_trace_hashes_object(std::string &object_name, gcs::Client* client) {
     std::string trace_hashes_bucket(TRACE_HASHES_BUCKET_PREFIX);
     std::string suffix(BUCKETS_SUFFIX);
     std::string object_content = read_object(trace_hashes_bucket+suffix, object_name, client);
@@ -246,7 +246,7 @@ std::vector<std::string> get_trace_ids_from_trace_hashes_object(std::string obje
     return response;
 }
 
-trace_structure morph_trace_object_to_trace_structure(std::string trace) {
+trace_structure morph_trace_object_to_trace_structure(std::string &trace) {
     trace_structure response;
 
     std::vector<std::string> trace_lines = split_by_string(trace, newline);
@@ -292,7 +292,7 @@ trace_structure morph_trace_object_to_trace_structure(std::string trace) {
     return response;
 }
 
-graph_type morph_trace_structure_to_boost_graph_type(trace_structure input_graph) {
+graph_type morph_trace_structure_to_boost_graph_type(trace_structure &input_graph) {
     graph_type output_graph;
 
     for (int i = 0; i < input_graph.num_nodes; i++) {

--- a/get_traces_by_structure.h
+++ b/get_traces_by_structure.h
@@ -111,21 +111,21 @@ struct vf2_callback_custom {
         IsomorphismMaps& isomorphism_maps_;
 };
 
-std::string get_root_service_name(std::string trace);
+std::string get_root_service_name(std::string &trace);
 std::vector<std::string> filter_trace_ids_based_on_query_timestamp(
-    std::vector<std::string> trace_ids,
-    std::string batch_name,
+    std::vector<std::string> &trace_ids,
+    std::string &batch_name,
     int start_time,
     int end_time,
-    std::string root_service_name,
+    std::string &root_service_name,
     gcs::Client* client);
 std::vector<std::unordered_map<int, int>> get_isomorphism_mappings(
-    trace_structure candidate_trace, trace_structure query_trace);
+    trace_structure &candidate_trace, trace_structure &query_trace);
 traces_by_structure process_trace_hashes_prefix_and_retrieve_relevant_trace_ids(
     std::string prefix, trace_structure query_trace, int start_time, int end_time,
     gcs::Client* client);
-trace_structure morph_trace_object_to_trace_structure(std::string trace);
-graph_type morph_trace_structure_to_boost_graph_type(trace_structure input_graph);
-std::vector<std::string> get_trace_ids_from_trace_hashes_object(std::string object_name, gcs::Client* client);
+trace_structure morph_trace_object_to_trace_structure(std::string &trace);
+graph_type morph_trace_structure_to_boost_graph_type(trace_structure &input_graph);
+std::vector<std::string> get_trace_ids_from_trace_hashes_object(std::string &object_name, gcs::Client* client);
 void print_trace_structure(trace_structure trace);
 #endif  // BY_STRUCT_H_ // NOLINT

--- a/graph_query.cc
+++ b/graph_query.cc
@@ -112,7 +112,7 @@ std::tuple<objname_to_matching_trace_ids, std::map<std::string, iso_to_span_id>>
     traces_by_structure &structural_results,
     std::vector<query_condition> &conditions,
     struct fetched_data &fetched,
-    return_value ret
+    return_value &ret
 ) {
     objname_to_matching_trace_ids to_return_traces;
     std::map<std::string, iso_to_span_id> trace_id_to_span_id_mappings;
@@ -131,7 +131,7 @@ std::tuple<objname_to_matching_trace_ids, std::map<std::string, iso_to_span_id>>
 }
 
 objname_to_matching_trace_ids intersect_index_results(
-    std::vector<objname_to_matching_trace_ids> index_results,
+    std::vector<objname_to_matching_trace_ids> &index_results,
     traces_by_structure &structural_results, bool verbose) {
     // Easiest solution is just keep a count
     // Eventually we should parallelize this, but I'm not optimizing it
@@ -192,12 +192,12 @@ std::string get_return_value_from_traces_data(
             return get_value_as_string(sp, ret.func, ret.type);
         }
     }
-    std::cerr << "didn't find the span " << span_to_find << " I was looking for " << std::endl << std::flush;
+    //std::cerr << "didn't find the span " << span_to_find << " I was looking for " << std::endl << std::flush;
     return "";
 }
 std::vector<std::string> get_return_value(
     std::tuple<objname_to_matching_trace_ids, std::map<std::string, iso_to_span_id>> &filtered,
-    return_value ret, fetched_data &data, trace_structure &query_trace, gcs::Client* client) {
+    return_value &ret, fetched_data &data, trace_structure &query_trace, gcs::Client* client) {
     std::vector<std::string> to_return;
 
     for (auto const &obj_to_trace_ids : std::get<0>(filtered)) {
@@ -278,9 +278,10 @@ fetched_data fetch_data(
     return response;
 }
 
-std::map<int, std::map<int, std::string>> does_trace_satisfy_conditions(std::string trace_id, std::string object_name,
+std::map<int, std::map<int, std::string>> does_trace_satisfy_conditions(
+    const std::string &trace_id, const std::string &object_name,
     std::vector<query_condition> &conditions, fetched_data& evaluation_data,
-    traces_by_structure &structural_results, return_value ret
+    traces_by_structure &structural_results, return_value& ret
 ) {
     // isomap_index_to_node_index_to_span_id -> ii_to_ni_to_si
     std::vector<std::map<int, std::map<int, std::string>>> ii_to_ni_to_si_data_for_all_conditions;
@@ -329,8 +330,9 @@ std::string get_service_name_for_node_index(
 }
 
 std::map<int, std::map<int, std::string>> get_iso_maps_indices_for_which_trace_satifies_curr_condition(
-    std::string trace_id, std::string batch_name, std::vector<query_condition>& conditions,
-    int curr_cond_ind, fetched_data& evaluation_data, traces_by_structure& structural_results, return_value ret
+    const std::string &trace_id, const std::string &batch_name,
+    std::vector<query_condition>& conditions,
+    int curr_cond_ind, fetched_data& evaluation_data, traces_by_structure& structural_results, return_value& ret
 ) {
     std::map<int, std::map<int, std::string>> response;
 
@@ -377,8 +379,8 @@ std::map<int, std::map<int, std::string>> get_iso_maps_indices_for_which_trace_s
 }
 
 bool does_span_satisfy_condition(
-    std::string span_id, std::string service_name,
-    query_condition condition, std::string batch_name, fetched_data& evaluation_data
+    std::string &span_id, std::string &service_name,
+    query_condition &condition, const std::string &batch_name, fetched_data& evaluation_data
 ) {
     if (evaluation_data.spans_objects_by_bn_sn.find(batch_name) == evaluation_data.spans_objects_by_bn_sn.end()
     || evaluation_data.spans_objects_by_bn_sn[batch_name].find(

--- a/graph_query.cc
+++ b/graph_query.cc
@@ -188,11 +188,11 @@ std::string get_return_value_from_traces_data(
         const opentelemetry::proto::trace::v1::Span *sp =
             &trace_data->resource_spans(0).scope_spans(0).spans(i);
         auto span_id = sp->opentelemetry::proto::trace::v1::Span::span_id();
-        if (hex_str(span_id, span_id.size()).compare(span_to_find) == 0) {
+        if (is_same_hex_str(span_id, span_id.size(), span_to_find)) {
             return get_value_as_string(sp, ret.func, ret.type);
         }
     }
-    std::cerr << "didn't find the span I was looking for " << std::endl << std::flush;
+    std::cerr << "didn't find the span " << span_to_find << " I was looking for " << std::endl << std::flush;
     return "";
 }
 std::vector<std::string> get_return_value(
@@ -394,8 +394,7 @@ bool does_span_satisfy_condition(
     for (int i=0; i < trace_data->resource_spans(0).scope_spans(0).spans_size(); i++) {
         sp = &(trace_data->resource_spans(0).scope_spans(0).spans(i));
 
-        std::string current_span_id = hex_str(sp->span_id(), sp->span_id().length());
-        if (current_span_id == span_id) {
+        if (is_same_hex_str(sp->span_id(), sp->span_id().length(), span_id)) {
             return does_condition_hold(sp, condition);
         }
     }

--- a/graph_query.cc
+++ b/graph_query.cc
@@ -192,7 +192,7 @@ std::string get_return_value_from_traces_data(
             return get_value_as_string(sp, ret.func, ret.type);
         }
     }
-    //std::cerr << "didn't find the span " << span_to_find << " I was looking for " << std::endl << std::flush;
+    std::cerr << "didn't find the span " << span_to_find << " I was looking for " << std::endl << std::flush;
     return "";
 }
 std::vector<std::string> get_return_value(

--- a/graph_query.h
+++ b/graph_query.h
@@ -60,12 +60,12 @@ fetched_data fetch_data(
 );
 index_type is_indexed(query_condition *condition, gcs::Client* client);
 bool does_span_satisfy_condition(
-    std::string span_id, std::string service_name,
-    query_condition condition, std::string batch_name, fetched_data& evaluation_data
+    std::string &span_id, std::string &service_name,
+    query_condition &condition, const std::string &batch_name, fetched_data& evaluation_data
 );
 std::map<int, std::map<int, std::string>> get_iso_maps_indices_for_which_trace_satifies_curr_condition(
-    std::string trace_id, std::string batch_name, std::vector<query_condition>& conditions,
-    int curr_cond_ind, fetched_data& evaluation_data, traces_by_structure& structural_results, return_value ret
+    const std::string &trace_id, const std::string &batch_name, std::vector<query_condition>& conditions,
+    int curr_cond_ind, fetched_data& evaluation_data, traces_by_structure& structural_results, return_value &ret
 );
 objname_to_matching_trace_ids get_traces_by_indexed_condition(
     int start_time, int end_time, query_condition *condition, index_type ind_type, gcs::Client* client);
@@ -74,19 +74,20 @@ std::tuple<objname_to_matching_trace_ids, std::map<std::string, iso_to_span_id>>
     traces_by_structure &structural_results,
     std::vector<query_condition> &conditions,
     struct fetched_data &fetched,
-    return_value ret
+    return_value &ret
 );
-std::map<int, std::map<int, std::string>> does_trace_satisfy_conditions(std::string trace_id, std::string object_name,
+std::map<int, std::map<int, std::string>> does_trace_satisfy_conditions(
+    const std::string& trace_id, const std::string& object_name,
     std::vector<query_condition> &conditions, fetched_data& evaluation_data,
-    traces_by_structure &structural_results, return_value ret
+    traces_by_structure &structural_results, return_value& ret
 );
 
 // ***************** query-related ******************************************
 std::vector<std::string> get_return_value(
     std::tuple<objname_to_matching_trace_ids, std::map<std::string, iso_to_span_id>> &filtered,
-    return_value ret, fetched_data &data, trace_structure &query_trace, gcs::Client* client);
+    return_value &ret, fetched_data &data, trace_structure &query_trace, gcs::Client* client);
 objname_to_matching_trace_ids intersect_index_results(
-    std::vector<objname_to_matching_trace_ids> index_results,
+    std::vector<objname_to_matching_trace_ids> &index_results,
     traces_by_structure &structural_results, bool verbose);
 
 int dummy_tests();


### PR DESCRIPTION
hex_str is taking an outsize amount of time in execution.  The majority of the uses are in order to get it into the right format to compare to something else.  To alleviate that, I made a special hex_str_compare function that exits early and doesn't do the whole comparison if they are not equivalent data.

I also changed a LOT of function definitions that were passing by copying everything when we should just pass by reference to be efficient.